### PR TITLE
Add CJS polyfills for node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.4.8] - 2024-12-20
+
+### Added
+- Add CJS version for node via `node.cjs`
+
+### Changed
+- Update package `main` and `exports.require` to use `node.cjs`
+
 ## [v0.4.7] - 2024-11-06
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shgysk8zer0/polyfills",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shgysk8zer0/polyfills",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@shgysk8zer0/polyfills",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "private": false,
   "type": "module",
   "description": "A collection of JavaScript polyfills",
-  "main": "./node.min.js",
+  "main": "./node.cjs",
   "module": "./node.min.js",
-  "unpkg": "./all.min.js",
+  "unpkg": "./browser.min.js",
   "exports": {
     ".": {
       "import": "./node.min.js",
-      "require": "./node.min.js"
+      "require": "./node.cjs"
     },
     "./*.js": {
       "import": "./*.js"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -44,5 +44,9 @@ export default [{
 		format: 'iife',
 		plugins: [t],
 		sourcemap: true,
+	}, {
+		file: 'node.cjs',
+		format: 'cjs',
+		plugins: [t],
 	}],
 }];


### PR DESCRIPTION
## Added
- Add CJS version for node via `node.cjs`

### Changed
- Update package `main` and `exports.require` to use `node.cjs`

## Description and issue

### List of significant changes made
-  
-  
