### PR TITLE
Bump version to 0.7.0 and fix npm publish tag

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Build Package
         run: npm run build --if-present
       - name: Publish to npm
-        run: npm publish stage --provenance --access public
+        run: npm publish --tag stage --provenance --access public
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shgysk8zer0/polyfills",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shgysk8zer0/polyfills",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shgysk8zer0/polyfills",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "private": false,
   "type": "module",
   "description": "A collection of JavaScript polyfills",


### PR DESCRIPTION
Update package.json version to 0.7.0 and adjust the GitHub Actions workflow to use the explicit '--tag stage' option when running npm publish so the package is published with the correct distribution tag.

## Description and issue

### List of significant changes made
-  
-  
