### PR TITLE
Add .npmrc and enforce strict npm scripts

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,33 +10,14 @@ on:
       - master
       - release/*
 jobs:
-  npm-test:
-    name: NPM Install and Test
+  build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          lfs: true
-          submodules: true
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: npm
-      - name: Get npm cache directory
-        id: npm-cache-dir
-        shell: bash
-        run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
-      - name: Restore cache
-        uses: actions/cache@v5
-        # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
-        id: npm-cache
-        with:
-          path: ${{ steps.npm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: ${{ runner.os }}-node-
-      - name: Install dependencies
-        run: npm ci --ignore-scripts --no-audit --no-fund
-      - name: Run npm test
-        run: npm test --if-present
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
+      with:
+        node-version-file: '.nvmrc'
+        cache: npm
+    - run: npm ci --ignore-scripts --no-audit --no-fund --strict-allow-scripts
+    - run: npm run build --if-present
+    - run: npm test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,7 +10,8 @@ on:
       - master
       - release/*
 jobs:
-  build:
+  npm-test:
+    name: NPM Install and Test
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -25,7 +25,7 @@ jobs:
           cache: npm
           registry-url: https://registry.npmjs.org
       - name: Install dependencies
-        run: npm ci --no-audit --no-fund
+        run: npm ci --no-audit --no-fund --strict-allow-scripts
       - name: Run tests
         run: npm test
       - name: Build Package

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+strict-allow-scripts=true
+allow-git=none
+allow-remote=none
+allow-file=none

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.8.2] - 2026-06-12
+
+### Added
+- Add `.npmrc` to harden `npm i` & `npm ci` operations
+
 ## [v0.8.1] - 2026-06-11
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shgysk8zer0/polyfills",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shgysk8zer0/polyfills",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shgysk8zer0/polyfills",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": false,
   "type": "module",
   "description": "A collection of JavaScript polyfills",


### PR DESCRIPTION
Add a .npmrc to harden npm installs (strict-allow-scripts plus disallowing git/remote/file installs). Update GitHub Actions workflows to use --strict-allow-scripts for npm ci and simplify the build job (adjust checkout/setup-node steps and run build/test). Bump package version to 0.8.2 and add an entry to CHANGELOG.

## Description and issue

### List of significant changes made
-  
-  
