### PR TITLE
Bump version to 0.8.5 and add local ESLint hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,10 @@ repos:
   rev: v8.16.3
   hooks:
   - id: gitleaks
-- repo: https://github.com/pre-commit/mirrors-eslint
-  rev: v8.38.0
+- repo: local
   hooks:
-  - id: eslint
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
-  hooks:
-  - id: end-of-file-fixer
-  - id: trailing-whitespace
+  - id: local-eslint
+    name: Run ESLint
+    entry: npm eslint --fix
+    language: system
+    types_or: [javascript, jsx, ts, tsx]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.8.5] - 2026-06-15
+
+### Added
+- Implement security changes provided by SecurityStep
+
 ## [v0.8.4] - 2026-06-12
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shgysk8zer0/polyfills",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shgysk8zer0/polyfills",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shgysk8zer0/polyfills",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "private": false,
   "type": "module",
   "description": "A collection of JavaScript polyfills",


### PR DESCRIPTION
Bump package version to 0.8.5 and add a changelog entry for the v0.8.5 release noting SecurityStep changes. Replace the external ESLint/pre-commit-hooks entries with a local pre-commit hook (local-eslint) that runs `npm eslint --fix`, and remove the end-of-file and trailing-whitespace hooks. These changes prepare the repo for the new release and enforce linting via the local system ESLint command.

## Description and issue

### List of significant changes made
-  
-  
